### PR TITLE
Use of separate socket object for handling data transfer

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,11 +11,14 @@ Unreleased
 Added
 ^^^^^
 * Arg to specify if the module is roaming or when connecting specify if roaming so that we know what to expect in the connection status.
+* capture_urc flag to _at_command(). So that it is possible to collect the URCs before the OK response.
+* Added the UbloxSocket and UDPSocket classes to be able to handle sockets independant from module.
 
 Changed
 ^^^^^^^
 * Removed operators name and map. Now you need to specify the operator with its MNO_ID. Swedish Telia is for example 24001.
 * Renamed eps_reg_status to registration_status. Even if it does not follow the naming in the ublox manual it is clearer in the code what it is.
+* create_socket now returns a UbloxSocket subclass.
 
 Deprecated
 ^^^^^^^^^^

--- a/ublox/socket.py
+++ b/ublox/socket.py
@@ -1,0 +1,26 @@
+import random
+
+
+class UbloxSocket:
+
+    def __init__(self, socket_id, module, source_port=None):
+        self.socket_id = socket_id
+        self.module = module
+        self.source_port = source_port or random.randrange(100, 65534, 1)
+
+    def sendto(self, bytes, address):
+        pass
+
+    def recvfrom(self, bufsize):
+        pass
+
+    def close(self):
+        self.module.close_socket(self.socket_id)
+
+
+
+class UDPSocket(UbloxSocket):
+
+    def sendto(self, bytes, address):
+        self.module.send_udp_data(host=address[0], port=address[1],
+                                  data=bytes.decode())


### PR DESCRIPTION
A separate socket object that mimics the behaviour of normal python sockets are returned on create_socket. Also the module keeps track of open sockets.
Fixes #1